### PR TITLE
Incorporate improvements from toftul/refractiveindex analysis

### DIFF
--- a/refractivesqlite/_units.py
+++ b/refractivesqlite/_units.py
@@ -1,0 +1,78 @@
+"""
+Wavelength unit conversion helpers.
+
+All internal computations use micrometres (um). Query methods accept
+wavelengths in nanometres (nm) by default; this module converts to/from
+that convention as needed.
+
+Supported units: 'm', 'mm', 'um', 'nm', 'A', 'cm-1', 'THz', 'eV'
+"""
+import numpy
+
+_h = 6.62607015e-34   # Planck constant (J·s)
+_c = 299792458.0      # Speed of light (m/s)
+_e = 1.602176634e-19  # Elementary charge (C)
+
+# hc in eV·nm
+_hc_eV_nm = _h * _c / _e * 1e9   # ≈ 1239.84198 eV·nm
+# c in nm·THz
+_c_nm_THz = _c * 1e-3             # ≈ 299792.458 nm·THz
+
+SUPPORTED_UNITS = ['m', 'mm', 'um', 'nm', 'A', 'cm-1', 'THz', 'eV']
+
+# Each entry is (to_nm, from_nm): callables that convert between the given
+# unit and nanometres. Both accept array-like input.
+_UNITS = {
+    'm':    (lambda x: numpy.asarray(x, dtype=float) * 1e9,
+             lambda nm: numpy.asarray(nm, dtype=float) * 1e-9),
+    'mm':   (lambda x: numpy.asarray(x, dtype=float) * 1e6,
+             lambda nm: numpy.asarray(nm, dtype=float) * 1e-6),
+    'um':   (lambda x: numpy.asarray(x, dtype=float) * 1e3,
+             lambda nm: numpy.asarray(nm, dtype=float) * 1e-3),
+    'nm':   (lambda x: numpy.asarray(x, dtype=float),
+             lambda nm: numpy.asarray(nm, dtype=float)),
+    'A':    (lambda x: numpy.asarray(x, dtype=float) * 0.1,
+             lambda nm: numpy.asarray(nm, dtype=float) * 10.0),
+    'cm-1': (lambda x: 1e7 / numpy.asarray(x, dtype=float),
+             lambda nm: 1e7 / numpy.asarray(nm, dtype=float)),
+    'THz':  (lambda x: _c_nm_THz / numpy.asarray(x, dtype=float),
+             lambda nm: _c_nm_THz / numpy.asarray(nm, dtype=float)),
+    'eV':   (lambda x: _hc_eV_nm / numpy.asarray(x, dtype=float),
+             lambda nm: _hc_eV_nm / numpy.asarray(nm, dtype=float)),
+}
+
+
+def to_nm(wavelength, unit):
+    """Convert *wavelength* expressed in *unit* to nanometres.
+
+    Parameters
+    ----------
+    wavelength : float or array-like
+    unit : str  one of SUPPORTED_UNITS
+
+    Returns
+    -------
+    numpy.ndarray  wavelength in nm
+    """
+    if unit not in _UNITS:
+        raise ValueError(
+            "Unknown unit '{}'. Supported: {}".format(unit, SUPPORTED_UNITS))
+    return _UNITS[unit][0](wavelength)
+
+
+def from_nm(wavelength_nm, unit):
+    """Convert *wavelength_nm* (in nm) to *unit*.
+
+    Parameters
+    ----------
+    wavelength_nm : float or array-like
+    unit : str  one of SUPPORTED_UNITS
+
+    Returns
+    -------
+    numpy.ndarray  wavelength in the requested unit
+    """
+    if unit not in _UNITS:
+        raise ValueError(
+            "Unknown unit '{}'. Supported: {}".format(unit, SUPPORTED_UNITS))
+    return _UNITS[unit][1](wavelength_nm)

--- a/refractivesqlite/builder.py
+++ b/refractivesqlite/builder.py
@@ -1,20 +1,39 @@
 import os
 import sqlite3
 
+try:
+    from yaml import CSafeLoader as _YamlLoader
+except ImportError:
+    from yaml import SafeLoader as _YamlLoader
 import yaml
 
 from refractivesqlite.models import Shelf, Book, Page, Entry
 from refractivesqlite import material as material_module
 
+# Module-level cache so repeated calls with the same path skip I/O
+_catalog_cache = {}
+
 
 def extract_entry_list(db_path):
+    """Return a list of :class:`~refractivesqlite.models.Entry` objects
+    parsed from *db_path*/library.yml.
+
+    Results are cached per normalised path so that the YAML file is read
+    at most once per process.
+    """
     entries = []
     referencePath = os.path.normpath(db_path)
+
+    if referencePath in _catalog_cache:
+        catalog = _catalog_cache[referencePath]
+    else:
+        library_yml_path = os.path.join(
+            referencePath, os.path.normpath('library.yml'))
+        with open(library_yml_path, 'r') as f:
+            catalog = yaml.load(f, Loader=_YamlLoader)
+        _catalog_cache[referencePath] = catalog
+
     idx = 0
-    library_yml_path = os.path.join(referencePath,
-                                    os.path.normpath("library.yml"))
-    with open(library_yml_path, "r") as f:
-        catalog = yaml.safe_load(f)
     for sh in catalog:
         shelf = Shelf(sh['SHELF'], sh['name'])
         for b in sh['content']:
@@ -22,11 +41,11 @@ def extract_entry_list(db_path):
                 book = Book(b['BOOK'], b['name'])
                 for p in b['content']:
                     if 'DIVIDER' not in p:
-                        page = Page(p['PAGE'],
-                                    p['name'],
-                                    os.path.join(referencePath,
-                                                 'data',
-                                                 os.path.normpath(p['data'])))
+                        page = Page(
+                            p['PAGE'],
+                            p['name'],
+                            os.path.join(referencePath, 'data',
+                                         os.path.normpath(p['data'])))
                         entries.append(Entry(str(idx), shelf, book, page))
                         idx += 1
     return entries
@@ -34,7 +53,7 @@ def extract_entry_list(db_path):
 
 def pretty_entry(entry):
     e = entry
-    return ",".join([e.id, e.shelf.shelf, e.book.book, e.page.page])
+    return ','.join([e.id, e.shelf.shelf, e.book.book, e.page.page])
 
 
 def print_pretty_entry_list(entries):
@@ -45,27 +64,28 @@ def print_pretty_entry_list(entries):
 def create_sqlite_database(refractiveindex_db_path,
                            new_sqlite_db,
                            interpolation_points=100):
-    '''
-    Creates a new sqlite database containing a pages, refractiveindex
-    and a extcoeff table.
+    """Create a new SQLite database with ``pages``, ``refractiveindex`` and
+    ``extcoeff`` tables populated from the refractiveindex.info YML data.
 
-    :param refractiveindex_db_path: Path to the refractiveindex db
-    :param new_sqlite_db: Path to the sqlite database
-    :param interpolation_points: The number of interpolation points
-    '''
+    :param refractiveindex_db_path: Path to the refractiveindex.info data dir.
+    :param new_sqlite_db: Destination path for the SQLite file.
+    :param interpolation_points: Interpolation points for formula materials.
+    """
     conn = sqlite3.connect(new_sqlite_db)
     c = conn.cursor()
-    c.execute('''DROP TABLE IF EXISTS pages;''')
-    c.execute('''DROP TABLE IF EXISTS refractiveindex;''')
-    c.execute('''DROP TABLE IF EXISTS extcoeff;''')
-    c.execute('CREATE TABLE pages'
-              '(pageid int, shelf text COLLATE NOCASE,'
-              'book text COLLATE NOCASE, page text COLLATE NOCASE,'
-              'filepath text COLLATE NOCASE,'
-              'hasrefractive integer, hasextinction integer,'
-              'rangeMin real, rangeMax real, points int)')
-    c.execute('CREATE TABLE refractiveindex'
-              '(pageid int, wave real, refindex real)')
+    c.execute('DROP TABLE IF EXISTS pages;')
+    c.execute('DROP TABLE IF EXISTS refractiveindex;')
+    c.execute('DROP TABLE IF EXISTS extcoeff;')
+    c.execute(
+        'CREATE TABLE pages'
+        '(pageid int, shelf text COLLATE NOCASE,'
+        'book text COLLATE NOCASE, page text COLLATE NOCASE,'
+        'filepath text COLLATE NOCASE,'
+        'hasrefractive integer, hasextinction integer,'
+        'rangeMin real, rangeMax real, points int)')
+    c.execute(
+        'CREATE TABLE refractiveindex'
+        '(pageid int, wave real, refindex real)')
     c.execute('CREATE TABLE extcoeff (pageid int, wave real, coeff real)')
     conn.commit()
     conn.close()
@@ -77,13 +97,7 @@ def create_sqlite_database(refractiveindex_db_path,
 def _populate_sqlite_database(refractiveindex_db_path,
                               new_sqlite_db,
                               interpolation_points=100):
-    '''
-    Insert and commit the materials to the sqlite database
-
-    :param refractiveindex_db_path: Path to the refractiveindex db
-    :param new_sqlite_db: Path to the sqlite database
-    :param interpolation_points: The number of interpolation points
-    '''
+    """Insert material data into an existing SQLite database."""
     entries = extract_entry_list(refractiveindex_db_path)
     conn = sqlite3.connect(new_sqlite_db)
     c = conn.cursor()
@@ -98,26 +112,27 @@ def _populate_sqlite_database(refractiveindex_db_path,
                 refr = mat.get_complete_refractive()
                 hasrefractive = 1
                 values = [[e.id, r[0], r[1]] for r in refr]
-                c.executemany('INSERT INTO refractiveindex VALUES (?,?,?)',
-                              values)
+                c.executemany(
+                    'INSERT INTO refractiveindex VALUES (?,?,?)', values)
             if mat.has_extinction():
                 ext = mat.get_complete_extinction()
                 hasextinction = 1
                 values = [[e.id, ex[0], ex[1]] for ex in ext]
                 c.executemany('INSERT INTO extcoeff VALUES (?,?,?)', values)
-            c.execute("INSERT INTO pages VALUES (?,?,?,?,?,?,?,?,?,?)",
-                      [e.id,
-                       e.shelf.shelf,
-                       e.book.book,
-                       e.page.page,
-                       os.sep.join(e.page.path.split(os.sep)[-3:]),
-                       hasrefractive,
-                       hasextinction,
-                       mat.rangeMin,
-                       mat.rangeMax,
-                       mat.points])
+            c.execute(
+                'INSERT INTO pages VALUES (?,?,?,?,?,?,?,?,?,?)',
+                [e.id,
+                 e.shelf.shelf,
+                 e.book.book,
+                 e.page.page,
+                 os.sep.join(e.page.path.split(os.sep)[-3:]),
+                 hasrefractive,
+                 hasextinction,
+                 mat.rangeMin,
+                 mat.rangeMax,
+                 mat.points])
         except Exception as error:
-            print("LOG:", pretty_entry(e), ":", error)
+            print('LOG:', pretty_entry(e), ':', error)
     conn.commit()
     conn.close()
-    print("***Wrote SQLite DB on ", new_sqlite_db)
+    print('***Wrote SQLite DB on', new_sqlite_db)

--- a/refractivesqlite/material.py
+++ b/refractivesqlite/material.py
@@ -6,16 +6,19 @@ from refractivesqlite.optical_data import (
     ExtinctionCoefficientData,
 )
 from refractivesqlite.exceptions import NoExtinctionCoefficient
+from refractivesqlite._units import to_nm, from_nm
 
 
 class Material:
-    """ Material class"""
+    """Material class — holds refractive index and extinction coefficient."""
+
     def __init__(self, filename, interpolation_points=100, empty=False):
         """
-
-        :param filename: The name of the material file
-        :interpolation_points=100: The number of interpolation_points
-        :empty=False: Create an empty material instance
+        :param filename: Path to the material YAML file.
+        :param interpolation_points: Number of interpolation points for
+                                     formula-based materials.
+        :param empty: If True, create an uninitialised instance (used by
+                      :meth:`FromLists`).
         """
         self.refractiveIndex = None
         self.extinctionCoefficient = None
@@ -23,17 +26,21 @@ class Material:
         if empty:
             return
 
-        f = open(filename)
-        try:
-            material = yaml.safe_load(f)
-        except yaml.YAMLError:
-            raise Exception('Bad Material YAML File.')
-        finally:
-            f.close()
+        with open(filename) as f:
+            try:
+                material = yaml.safe_load(f)
+            except yaml.YAMLError:
+                raise Exception('Bad Material YAML File.')
 
         previous_formula = False
+        formula = None
+        rangeMin = None
+        rangeMax = None
+        coefficients = None
+
         for data in material['DATA']:
-            if (data['type'].split())[0] == 'tabulated':
+            dtype = data['type'].split()
+            if dtype[0] == 'tabulated':
                 rows = data['data'].split('\n')
                 splitrows = [c.split() for c in rows]
                 wavelengths = []
@@ -47,15 +54,14 @@ class Material:
                             k.append(float(s[2]))
                 self.points = len(wavelengths)
 
-                if (data['type'].split())[1] == 'n':
+                if dtype[1] == 'n':
                     if self.refractiveIndex is not None:
-                        Exception('Bad Material YAML File')
-
+                        raise Exception('Bad Material YAML File')
                     self.refractiveIndex = RefractiveIndexData.\
                         SetupRefractiveIndex(formula=-1,
                                              wavelengths=wavelengths,
                                              values=n)
-                elif (data['type'].split())[1] == 'k':
+                elif dtype[1] == 'k':
                     self.extinctionCoefficient = ExtinctionCoefficientData.\
                         SetupExtinctionCoefficient(wavelengths, n)
                     if previous_formula:
@@ -64,24 +70,27 @@ class Material:
                                 formula=formula, rangeMin=rangeMin,
                                 rangeMax=rangeMax, coefficients=coefficients,
                                 interpolation_points=self.points)
-                elif (data['type'].split())[1] == 'nk':
+                elif dtype[1] == 'nk':
                     if self.refractiveIndex is not None:
-                        Exception('Bad Material YAML File')
+                        raise Exception('Bad Material YAML File')
                     self.refractiveIndex = RefractiveIndexData.\
                         SetupRefractiveIndex(formula=-1,
                                              wavelengths=wavelengths,
                                              values=n)
                     self.extinctionCoefficient = ExtinctionCoefficientData.\
                         SetupExtinctionCoefficient(wavelengths, k)
-            elif (data['type'].split())[0] == 'formula':
 
+            elif dtype[0] == 'formula':
                 if self.refractiveIndex is not None:
-                    Exception('Bad Material YAML File')
+                    raise Exception('Bad Material YAML File')
 
-                formula = int((data['type'].split())[1])
+                formula = int(dtype[1])
                 coefficients = [float(s) for s in data['coefficients'].split()]
-                rangeMin, rangeMax = map(float,
-                                         data['wavelength_range'].split())
+
+                # Support both 'range' (newer upstream) and 'wavelength_range'
+                range_key = 'range' if 'range' in data else 'wavelength_range'
+                rangeMin, rangeMax = map(float, data[range_key].split())
+
                 previous_formula = True
                 self.refractiveIndex = RefractiveIndexData.\
                     SetupRefractiveIndex(formula=formula,
@@ -89,6 +98,7 @@ class Material:
                                          rangeMax=rangeMax,
                                          coefficients=coefficients,
                                          interpolation_points=self.points)
+
         if self.refractiveIndex is not None:
             self.rangeMin = self.refractiveIndex.rangeMin
             self.rangeMax = self.refractiveIndex.rangeMax
@@ -96,138 +106,169 @@ class Material:
             self.rangeMin = self.extinctionCoefficient.rangeMin
             self.rangeMax = self.extinctionCoefficient.rangeMax
 
-    def get_refractiveindex(self, wavelength):
-        """
-        Get the refractive index at a certain wavelenght
+    # ------------------------------------------------------------------
+    # Query methods
+    # ------------------------------------------------------------------
 
-        :param wavelength: The wavelength in nm
-        :returns: refractive index
-        :raises Exception:
+    def get_refractiveindex(self, wavelength, unit='nm'):
+        """Return the refractive index at *wavelength*.
+
+        :param wavelength: Wavelength (scalar or array-like) in *unit*.
+        :param unit: Wavelength unit — one of 'm', 'mm', 'um', 'nm', 'A',
+                     'cm-1', 'THz', 'eV'. Default: 'nm'.
+        :returns: Refractive index (float or ndarray).
+        :raises Exception: If no refractive index is defined.
         """
         if self.refractiveIndex is None:
             raise Exception('No refractive index specified for this material')
-        else:
-            return self.refractiveIndex.get_refractiveindex(wavelength)
+        wl_nm = to_nm(wavelength, unit)
+        return self.refractiveIndex.get_refractiveindex(wl_nm)
 
-    def get_extinctioncoefficient(self, wavelength):
-        """
-        Get the extinction coefficient
+    def get_extinctioncoefficient(self, wavelength, unit='nm'):
+        """Return the extinction coefficient at *wavelength*.
 
-        :param wavelength:
-        :returns: extiction coefficient
-        :raises NoExtinctionCoefficient:
+        :param wavelength: Wavelength (scalar or array-like) in *unit*.
+        :param unit: Wavelength unit. Default: 'nm'.
+        :returns: Extinction coefficient (float or ndarray).
+        :raises NoExtinctionCoefficient: If no k data is defined.
         """
         if self.extinctionCoefficient is None:
-            raise NoExtinctionCoefficient('No extinction coefficient'
-                                          'specified for this material')
+            raise NoExtinctionCoefficient(
+                'No extinction coefficient specified for this material')
+        wl_nm = to_nm(wavelength, unit)
+        return self.extinctionCoefficient.get_extinction_coefficient(wl_nm)
+
+    def get_epsilon(self, wavelength, unit='nm',
+                    convention='exp_minus_i_omega_t'):
+        """Return the complex permittivity ε = (n + ik)² at *wavelength*.
+
+        If no extinction coefficient is available, k is taken as 0.
+
+        :param wavelength: Wavelength (scalar or array-like) in *unit*.
+        :param unit: Wavelength unit. Default: 'nm'.
+        :param convention: Sign convention for the imaginary part.
+            ``'exp_minus_i_omega_t'`` (default, physics/optics) gives
+            ε = (n + ik)²; ``'exp_plus_i_omega_t'`` (engineering) gives
+            ε = (n − ik)².
+        :returns: Complex permittivity (complex or ndarray of complex).
+        """
+        n = self.get_refractiveindex(wavelength, unit=unit)
+        try:
+            k = self.get_extinctioncoefficient(wavelength, unit=unit)
+        except NoExtinctionCoefficient:
+            k = 0.0
+        if convention == 'exp_minus_i_omega_t':
+            return (n + 1j * k) ** 2
         else:
-            return self.extinctionCoefficient.\
-                get_extinction_coefficient(wavelength)
+            return (n - 1j * k) ** 2
 
-    def get_complete_extinction(self):
-        '''
-        Get the complete extinction coefficient information
+    def get_wl_range(self, unit='nm'):
+        """Return the valid wavelength range as *(min, max)* in *unit*.
 
-        :returns: The extinction coefficient informations as a list of lists
-        '''
+        :param unit: Wavelength unit. Default: 'nm'.
+        :returns: Tuple (wl_min, wl_max) in the requested unit.
+        """
+        # rangeMin/rangeMax are stored in um; convert to nm first, then to unit
+        lo = float(from_nm(self.rangeMin * 1000.0, unit))
+        hi = float(from_nm(self.rangeMax * 1000.0, unit))
+        return (min(lo, hi), max(lo, hi))
 
-        if self.has_extinction():
-            return self.extinctionCoefficient.get_complete_extinction()
-        else:
-            return None
+    # ------------------------------------------------------------------
+    # Bulk data retrieval
+    # ------------------------------------------------------------------
 
     def get_complete_refractive(self):
-        '''
-        Get the complete refractive information
-
-        :returns: The refractive index informations as a list of lists
-        '''
+        """Return all refractive index data as a list of [wl_um, n] pairs."""
         if self.has_refractive():
             return self.refractiveIndex.get_complete_refractive()
-        else:
-            return None
+        return None
+
+    def get_complete_extinction(self):
+        """Return all extinction coefficient data as a list of [wl_um, k] pairs."""
+        if self.has_extinction():
+            return self.extinctionCoefficient.get_complete_extinction()
+        return None
+
+    # ------------------------------------------------------------------
+    # Predicates
+    # ------------------------------------------------------------------
 
     def has_refractive(self):
-        '''
-        Checks if there is a refractive index
-        '''
+        """True if a refractive index is available."""
         return self.refractiveIndex is not None
 
     def has_extinction(self):
-        '''
-        Checks if there is a extinction coefficient
-        '''
+        """True if an extinction coefficient is available."""
         return self.extinctionCoefficient is not None
 
+    # ------------------------------------------------------------------
+    # Metadata / I/O
+    # ------------------------------------------------------------------
+
     def get_page_info(self):
-        '''
-        Get the page informations
-        '''
+        """Return the page info dict."""
         return self.pageinfo
 
     def to_csv(self, output):
-        '''
-        Safe this material as a comma seperated value list
+        """Write this material's data to CSV file(s).
 
-        :param output: The output file
-        '''
+        :param output: Output path. Suffix ``(nk).csv``, ``(n).csv`` or
+                       ``(k).csv`` is appended automatically.
+        """
         refr = self.get_complete_refractive()
         ext = self.get_complete_extinction()
-        # FizzFuzz
-        if self.has_refractive() and self.has_extinction() and\
+        if self.has_refractive() and self.has_extinction() and \
                 len(refr) == len(ext):
-            header = "wl,n,k\n"
-            output_f = open(output.replace(".csv", "(nk).csv"), 'w')
-            output_f.write(header)
-            for i in range(len(refr)):
-                output_f.write(",".join(list(
-                    map(str, [refr[i][0], refr[i][1], ext[i][1]])))+"\n")
-            output_f.close()
-            print("Wrote", output.replace(".csv", "(nk).csv"))
+            path = output.replace('.csv', '(nk).csv')
+            with open(path, 'w') as f:
+                f.write('wl,n,k\n')
+                for i in range(len(refr)):
+                    f.write(','.join(
+                        map(str, [refr[i][0], refr[i][1], ext[i][1]])) + '\n')
+            print('Wrote', path)
         else:
             if self.has_refractive():
-                output_f = open(output.replace(".csv", "(n).csv"), 'w')
-                header = "wl,n\n"
-                output_f.write(header)
-                for i in range(len(refr)):
-                    output_f.write(",".join(list(
-                        map(str, [refr[i][0], refr[i][1]])))+"\n")
-                output_f.close()
-                print("Wrote", output.replace(".csv", "(n).csv"))
+                path = output.replace('.csv', '(n).csv')
+                with open(path, 'w') as f:
+                    f.write('wl,n\n')
+                    for row in refr:
+                        f.write(','.join(map(str, row)) + '\n')
+                print('Wrote', path)
             if self.has_extinction():
-                output_f = open(output.replace(".csv", "(k).csv"), 'w')
-                header = "wl,k\n"
-                output_f.write(header)
-                for i in range(len(ext)):
-                    output_f.write(",".join(list(
-                        map(str, [ext[i][0], ext[i][1]])))+"\n")
-                output_f.close()
-                print("Wrote", output.replace(".csv", "(k).csv"))
+                path = output.replace('.csv', '(k).csv')
+                with open(path, 'w') as f:
+                    f.write('wl,k\n')
+                    for row in ext:
+                        f.write(','.join(map(str, row)) + '\n')
+                print('Wrote', path)
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
 
     @staticmethod
     def FromLists(pageinfo, wavelengths_r=None, refractive=None,
                   wavelengths_e=None, extinction=None):
-        '''
-        Create a material from lists of wavelength refractive indices
-        and extinction coefficients
+        """Create a :class:`Material` directly from Python lists.
 
-        :param pageinfo: The pageinfo of the material
-        :param wavelengths_r: A list of wavelengths for the refractive index
-        :param refractive: A list of refractive indices
-        :param wavelengths_e: A list of wavelengths_e for the extinction coeff
-        :param extinction: A list of extinction coefficients
-        :returns: A material
-        '''
-        mat = Material("", empty=True)
+        :param pageinfo: Dict with keys ``shelf``, ``book``, ``page``, etc.
+        :param wavelengths_r: Wavelengths (um) for refractive index.
+        :param refractive: Refractive index values.
+        :param wavelengths_e: Wavelengths (um) for extinction coefficient.
+        :param extinction: Extinction coefficient values.
+        :returns: :class:`Material`
+        """
+        mat = Material('', empty=True)
         mat.pageinfo = pageinfo
         if refractive is not None:
-            mat.refractiveIndex = TabulatedRefractiveIndexData.\
-                FromLists(wavelengths_r, refractive)
+            mat.refractiveIndex = TabulatedRefractiveIndexData.FromLists(
+                wavelengths_r, refractive)
             mat.rangeMin = mat.refractiveIndex.rangeMin
             mat.rangeMax = mat.refractiveIndex.rangeMax
         if extinction is not None:
-            mat.extinctionCoefficient = ExtinctionCoefficientData.\
-                FromLists(wavelengths_e, extinction)
-            mat.rangeMin = mat.extinctionCoefficient.rangeMin
-            mat.rangeMax = mat.extinctionCoefficient.rangeMax
+            mat.extinctionCoefficient = ExtinctionCoefficientData.FromLists(
+                wavelengths_e, extinction)
+            if refractive is None:
+                mat.rangeMin = mat.extinctionCoefficient.rangeMin
+                mat.rangeMax = mat.extinctionCoefficient.rangeMax
         return mat

--- a/refractivesqlite/optical_data.py
+++ b/refractivesqlite/optical_data.py
@@ -8,11 +8,11 @@ class RefractiveIndexData:
     @staticmethod
     def SetupRefractiveIndex(formula, **kwargs):
         """
-        :param formula: An integer value specifying the formula to use
-                        pass -1 to create a tabulated refractive index data
-        :param kwargs: kwargs passed to the FormulaRefractiveIndexData
-                       or TabulatedRefractiveIndexData
-        :returns: A formula or tabulated refractive index data
+        :param formula: An integer value specifying the formula to use.
+                        Pass -1 to create tabulated refractive index data.
+        :param kwargs: Passed to FormulaRefractiveIndexData or
+                       TabulatedRefractiveIndexData.
+        :returns: A formula or tabulated refractive index data object.
         :raises Exception:
         """
         if formula >= 0:
@@ -23,27 +23,15 @@ class RefractiveIndexData:
             raise Exception('Bad RefractiveIndex data type')
 
     def get_refractiveindex(self, wavelength):
-        """
-        Not implemented yet
-
-        :param wavelength:
-        :raise NotImplementedError:
-        """
-        raise NotImplementedError('Different for functionally'
-                                  'and experimentally defined materials')
+        raise NotImplementedError(
+            'Different for formula and tabulated materials')
 
 
 class FormulaRefractiveIndexData:
-    """Formula RefractiveIndex class"""
+    """Formula-based refractive index (dispersion formulas 1–9)."""
 
     def __init__(self, formula, rangeMin, rangeMax, coefficients,
                  interpolation_points):
-        """
-        :param formula: An integer value specifying the formula
-        :param rangeMin: The lower bound for the wavelength
-        :param rangeMax: The upper bound for the wavelength
-        :param coefficients: Coefficient to interpolate over
-        """
         self.formula = formula
         self.rangeMin = rangeMin
         self.rangeMax = rangeMax
@@ -51,187 +39,153 @@ class FormulaRefractiveIndexData:
         self.interpolation_points = interpolation_points
 
     def get_complete_refractive(self):
-        '''
-        Get the complete refractive index for the whole wavelength intervall
+        """Return refractive index over the full wavelength range.
 
-        :returns: A list of refractive indices over the whole
-                  wavelength intervall (len = interpolation_points)
-        '''
+        Returns a list of [wavelength_um, n] pairs of length
+        *interpolation_points*.
+        """
         wavelength = numpy.linspace(
             self.rangeMin, self.rangeMax, num=self.interpolation_points)
-        extlist = [[
-            wavelength[i],
-            self.get_refractiveindex(wavelength[i] * 1000)]
-            for i in range(len(wavelength))]
-        return extlist
+        return [
+            [wavelength[i], float(self.get_refractiveindex(wavelength[i] * 1000))]
+            for i in range(len(wavelength))
+        ]
 
     def get_refractiveindex(self, wavelength):
+        """Return the refractive index at *wavelength* (in nm).
+
+        Accepts scalar or array-like input. Out-of-range values return NaN.
+
+        :param wavelength: Wavelength in nm (scalar or array-like).
+        :returns: Refractive index (float or ndarray).
         """
-        Get the refractive index at a certain wavelength
-        using the speficied interpolation formula
+        wl_arr = numpy.asarray(wavelength, dtype=float) / 1000.0  # nm → um
+        scalar_input = wl_arr.ndim == 0
+        wl_arr = numpy.atleast_1d(wl_arr)
 
-        :param wavelength:
-        :returns: The interpolated refractive index at wavelength
-        :raises Exception:
-        """
-        wavelength /= 1000.0
-        if self.rangeMin <= wavelength <= self.rangeMax:
-            formula_type = self.formula
-            coefficients = self.coefficients
-            n = 0
-            if formula_type == 1:  # Sellmeier
-                nsq = 1 + coefficients[0]
+        in_range = (wl_arr >= self.rangeMin) & (wl_arr <= self.rangeMax)
+        result = numpy.full(wl_arr.shape, numpy.nan)
 
-                def sellmeier(c1, c2, w):
-                    return c1 * (w ** 2) / (w ** 2 - c2 ** 2)
+        wl = wl_arr[in_range]
+        if wl.size == 0:
+            return float('nan') if scalar_input else result
 
-                for i in range(1, len(coefficients), 2):
-                    nsq += sellmeier(coefficients[i],
-                                     coefficients[i + 1],
-                                     wavelength)
-                n = numpy.sqrt(nsq)
-            elif formula_type == 2:  # Sellmeier-2
-                nsq = 1 + coefficients[0]
+        formula_type = self.formula
+        C = self.coefficients
+        n = numpy.zeros(wl.shape)
 
-                def sellmeier2(c1, c2, w):
-                    return c1 * (w ** 2) / (w ** 2 - c2)
-                for i in range(1, len(coefficients), 2):
-                    nsq += sellmeier2(coefficients[i],
-                                      coefficients[i + 1],
-                                      wavelength)
-                n = numpy.sqrt(nsq)
-            elif formula_type == 3:  # Polynomal
-                def polynomial(c1, c2, w):
-                    return c1 * w ** c2
-                nsq = coefficients[0]
-                for i in range(1, len(coefficients), 2):
-                    nsq += polynomial(coefficients[i],
-                                      coefficients[i + 1],
-                                      wavelength)
-                n = numpy.sqrt(nsq)
-            elif formula_type == 4:  # RefractiveIndex.INFO
-                def riinfo(wl, ci, cj, ck, cl):
-                    return ci * wl**cj / (wl**2 - ck**cl)
-                n = coefficients[0]
-                n += riinfo(wavelength, *coefficients[1:5])
-                n += riinfo(wavelength, *coefficients[5:9])
-                for kk in range(len(coefficients[9:]) // 2):
-                    n += coefficients[9+kk] * wavelength**coefficients[9+kk+1]
+        if formula_type == 1:  # Sellmeier
+            nsq = 1.0 + C[0]
+            for i in range(1, len(C), 2):
+                nsq = nsq + C[i] * wl**2 / (wl**2 - C[i + 1]**2)
+            n = numpy.sqrt(nsq)
 
-                n = numpy.sqrt(n)
-            elif formula_type == 5:  # Cauchy
-                def cauchy(c1, c2, w):
-                    return c1 * w ** c2
-                n = coefficients[0]
-                for i in range(1, len(coefficients), 2):
-                    n += cauchy(coefficients[i],
-                                coefficients[i + 1],
-                                wavelength)
-            elif formula_type == 6:  # Gasses
-                def gasses(c1, c2, w):
-                    return c1 / (c2 - w ** (-2))
-                n = 1 + coefficients[0]
-                for i in range(1, len(coefficients), 2):
-                    n += gasses(coefficients[i],
-                                coefficients[i + 1],
-                                wavelength)
-            elif formula_type == 7:  # Herzberger
-                n = coefficients[0]
-                n += coefficients[1] / (wavelength**2 - 0.028)
-                n += coefficients[2] * (1 / (wavelength**2 - 0.028))**2
-                for i, cc in enumerate(coefficients[3:]):
-                    n += cc * wavelength**(2*(i+1))
-            elif formula_type == 8:  # Retro
-                n = coefficients[0]
-                n += coefficients[1] * wavelength**2 /\
-                    (wavelength**2 - coefficients[2])
-                n += coefficients[3] * wavelength**2
-                n = numpy.sqrt(-(2 * n + 1) / (n - 1))
-            elif formula_type == 9:  # Exotic
-                n = coefficients[0]
-                n += coefficients[1] / (wavelength**2 - coefficients[2])
-                n += coefficients[3] * (wavelength - coefficients[4]) / \
-                    ((wavelength - coefficients[4])**2 + coefficients[5])
-                n = numpy.sqrt(n)
-            else:
-                raise Exception('Bad formula type')
-            return n
+        elif formula_type == 2:  # Sellmeier-2
+            nsq = 1.0 + C[0]
+            for i in range(1, len(C), 2):
+                nsq = nsq + C[i] * wl**2 / (wl**2 - C[i + 1])
+            n = numpy.sqrt(nsq)
+
+        elif formula_type == 3:  # Polynomial
+            nsq = C[0]
+            for i in range(1, len(C), 2):
+                nsq = nsq + C[i] * wl**C[i + 1]
+            n = numpy.sqrt(nsq)
+
+        elif formula_type == 4:  # RefractiveIndex.INFO
+            # Fixed: step-4 loop for Lorentz terms, step-2 for polynomial tail
+            # Zero-pad to avoid index errors with short coefficient lists
+            padded = list(C) + [0.0] * 20
+            nsq = padded[0]
+            for i in range(1, min(9, len(C)), 4):
+                nsq = nsq + padded[i] * wl**padded[i + 1] / (
+                    wl**2 - padded[i + 2]**padded[i + 3])
+            for i in range(9, len(C), 2):
+                nsq = nsq + padded[i] * wl**padded[i + 1]
+            n = numpy.sqrt(nsq)
+
+        elif formula_type == 5:  # Cauchy
+            n = C[0]
+            for i in range(1, len(C), 2):
+                n = n + C[i] * wl**C[i + 1]
+
+        elif formula_type == 6:  # Gases
+            n = 1.0 + C[0]
+            for i in range(1, len(C), 2):
+                n = n + C[i] / (C[i + 1] - wl**(-2))
+
+        elif formula_type == 7:  # Herzberger
+            n = C[0]
+            n = n + C[1] / (wl**2 - 0.028)
+            n = n + C[2] * (1.0 / (wl**2 - 0.028))**2
+            for i, cc in enumerate(C[3:]):
+                n = n + cc * wl**(2 * (i + 1))
+
+        elif formula_type == 8:  # Retro
+            tmp = C[0]
+            tmp = tmp + C[1] * wl**2 / (wl**2 - C[2])
+            tmp = tmp + C[3] * wl**2
+            n = numpy.sqrt(-(2 * tmp + 1) / (tmp - 1))
+
+        elif formula_type == 9:  # Exotic
+            tmp = C[0]
+            tmp = tmp + C[1] / (wl**2 - C[2])
+            tmp = tmp + C[3] * (wl - C[4]) / ((wl - C[4])**2 + C[5])
+            n = numpy.sqrt(tmp)
+
         else:
-            raise Exception('Wavelength {} is out of bounds.'
-                            'Correct range(um): ({}, {})'.
-                            format(wavelength, self.rangeMin, self.rangeMax))
+            raise Exception('Bad formula type: {}'.format(formula_type))
+
+        result[in_range] = n
+        return float(result[0]) if scalar_input else result
 
 
 class TabulatedRefractiveIndexData:
-    """Tabulated RefractiveIndex class"""
+    """Tabulated refractive index with linear interpolation."""
 
     def __init__(self, wavelengths, values):
-        """
-        Crete a TabulatedRefractiveIndexData from a list of
-        wavelengths and values
-
-        :param wavelengths:
-        :param values:
-        """
-        self.rangeMin = numpy.min(wavelengths)
-        self.rangeMax = numpy.max(wavelengths)
-
-        if self.rangeMin == self.rangeMax:
-            self.refractiveFunction = values[0]
-        else:
-            self.refractiveFunction = scipy.interpolate.interp1d(wavelengths,
-                                                                 values)
+        self.rangeMin = float(numpy.min(wavelengths))
+        self.rangeMax = float(numpy.max(wavelengths))
         self.wavelengths = wavelengths
         self.coefficients = values
 
+        if self.rangeMin == self.rangeMax:
+            _val = float(values[0])
+            self.refractiveFunction = lambda x: numpy.full(
+                numpy.asarray(x).shape or (), _val)
+        else:
+            self.refractiveFunction = scipy.interpolate.interp1d(
+                wavelengths, values, bounds_error=False,
+                fill_value=numpy.nan)
+
     @staticmethod
     def FromLists(wavelengths, values):
-        """
-        Crete a TabulatedRefractiveIndexData from a list of
-        wavelengths and values
-        """
         return TabulatedRefractiveIndexData(wavelengths, values)
 
     def get_refractiveindex(self, wavelength):
+        """Return the refractive index at *wavelength* (nm).
+
+        Accepts scalar or array-like input. Out-of-range values return NaN.
         """
-        Get the refractive index at a certain wavelength
-        :param wavelength:
-        :returns: The refractive at wavelength
-        :raises Exception:
-        """
-        wavelength /= 1000.0
-        if self.rangeMin == self.rangeMax and self.rangeMin == wavelength:
-            return self.refractiveFunction
-        elif self.rangeMin <= wavelength <= self.rangeMax and\
-                self.rangeMin != self.rangeMax:
-            return self.refractiveFunction(wavelength)
-        else:
-            raise Exception('Wavelength {} is out of bounds.'
-                            'Correct range(um): ({}, {})'
-                            .format(wavelength, self.rangeMin, self.rangeMax))
+        wl = numpy.asarray(wavelength, dtype=float) / 1000.0  # nm → um
+        scalar_input = wl.ndim == 0
+        result = self.refractiveFunction(wl)
+        if scalar_input:
+            return float(result)
+        return result
 
     def get_complete_refractive(self):
-        """
-        Geth the complete refractive inde data as a list of lists
-
-        :returns: The refractive index data in the form [wavlenght, index]
-        """
-        extlist = [[
-            self.wavelengths[i], self.coefficients[i]]
-            for i in range(len(self.wavelengths))]
-        return extlist
+        return [
+            [self.wavelengths[i], self.coefficients[i]]
+            for i in range(len(self.wavelengths))
+        ]
 
 
 class ExtinctionCoefficientData:
-    """ExtinctionCofficient class"""
+    """Tabulated extinction coefficient with linear interpolation."""
 
     @staticmethod
     def SetupExtinctionCoefficient(wavelengths, values):
-        """
-        :param wavelengths:
-        :param values:
-        :return:
-        """
         return ExtinctionCoefficientData(wavelengths, values)
 
     @staticmethod
@@ -239,42 +193,28 @@ class ExtinctionCoefficientData:
         return ExtinctionCoefficientData(wavelengths, values)
 
     def __init__(self, wavelengths, coefficients):
-        """
-        :param wavelengths: A list of wavelengths
-        :param coefficients: A list of extinction coefficients
-        """
-        self.extCoeffFunction = scipy.interpolate.interp1d(wavelengths,
-                                                           coefficients)
-        self.rangeMin = numpy.min(wavelengths)
-        self.rangeMax = numpy.max(wavelengths)
+        self.rangeMin = float(numpy.min(wavelengths))
+        self.rangeMax = float(numpy.max(wavelengths))
         self.wavelengths = wavelengths
         self.coefficients = coefficients
+        self.extCoeffFunction = scipy.interpolate.interp1d(
+            wavelengths, coefficients, bounds_error=False,
+            fill_value=numpy.nan)
 
     def get_extinction_coefficient(self, wavelength):
-        """
-        Get the interpolated extinction coefficient at a wavelength
+        """Return the extinction coefficient at *wavelength* (nm).
 
-        :param wavelength:
-        :returns: The extinction coefficient at wavelength
-        :raises Exception:
+        Accepts scalar or array-like input. Out-of-range values return NaN.
         """
-        wavelength /= 1000.0
-        if self.rangeMin <= wavelength <= self.rangeMax:
-            return self.extCoeffFunction(wavelength)
-        else:
-            raise Exception('Wavelength {} is out of bounds.'
-                            'Correct range(um): ({}, {})'.
-                            format(wavelength, self.rangeMin, self.rangeMax))
+        wl = numpy.asarray(wavelength, dtype=float) / 1000.0  # nm → um
+        scalar_input = wl.ndim == 0
+        result = self.extCoeffFunction(wl)
+        if scalar_input:
+            return float(result)
+        return result
 
     def get_complete_extinction(self):
-        '''
-        Get the complete extinction coefficient for the whole
-        wavelength intervall
-
-        :returns: A list of refractive indices over the whole
-                  wavelength intervall (len = interpolation_points)
-        '''
-        extlist = [[
-            self.wavelengths[i], self.coefficients[i]]
-            for i in range(len(self.wavelengths))]
-        return extlist
+        return [
+            [self.wavelengths[i], self.coefficients[i]]
+            for i in range(len(self.wavelengths))
+        ]

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,3 +1,6 @@
+import math
+
+import numpy
 import pytest
 
 from refractivesqlite.material import Material
@@ -46,14 +49,32 @@ class TestMaterialFromLists:
         assert mat.has_refractive()
         assert mat.has_extinction()
 
-    def test_get_refractiveindex(self):
+    def test_get_refractiveindex_default_unit(self):
         mat = self._make_n_only()
-        n = mat.get_refractiveindex(500)
+        n = mat.get_refractiveindex(500)  # nm
         assert 1.3 < n < 1.6
 
-    def test_get_extinctioncoefficient(self):
+    def test_get_refractiveindex_um_unit(self):
+        mat = self._make_n_only()
+        n = mat.get_refractiveindex(0.5, unit='um')  # 0.5 um = 500 nm
+        assert 1.3 < n < 1.6
+
+    def test_get_refractiveindex_eV_unit(self):
+        mat = self._make_n_only()
+        # 500 nm ↔ ~2.48 eV
+        n = mat.get_refractiveindex(2.48, unit='eV')
+        assert 1.3 < n < 1.6
+
+    def test_get_refractiveindex_array_input(self):
+        mat = self._make_n_only()
+        wls = numpy.array([300, 500, 700])  # nm
+        result = mat.get_refractiveindex(wls)
+        assert result.shape == (3,)
+        assert not numpy.any(numpy.isnan(result))
+
+    def test_get_extinctioncoefficient_default_unit(self):
         mat = self._make_k_only()
-        k = mat.get_extinctioncoefficient(500)
+        k = mat.get_extinctioncoefficient(500)  # nm
         assert 0.0 < k < 0.05
 
     def test_get_extinctioncoefficient_missing_raises(self):
@@ -85,3 +106,54 @@ class TestMaterialFromLists:
         mat = self._make_k_only()
         assert mat.rangeMin == 0.3
         assert mat.rangeMax == 0.7
+
+    # ------------------------------------------------------------------
+    # get_epsilon
+    # ------------------------------------------------------------------
+
+    def test_get_epsilon_n_only(self):
+        mat = self._make_n_only()
+        eps = mat.get_epsilon(500)
+        # k=0 → eps = n² (real)
+        n = mat.get_refractiveindex(500)
+        assert abs(eps.real - n ** 2) < 1e-12
+        assert abs(eps.imag) < 1e-12
+
+    def test_get_epsilon_nk(self):
+        mat = self._make_nk()
+        eps = mat.get_epsilon(500)
+        n = mat.get_refractiveindex(500)
+        k = mat.get_extinctioncoefficient(500)
+        expected = (n + 1j * k) ** 2
+        assert abs(eps - expected) < 1e-12
+
+    def test_get_epsilon_engineering_convention(self):
+        mat = self._make_nk()
+        eps = mat.get_epsilon(500, convention='exp_plus_i_omega_t')
+        n = mat.get_refractiveindex(500)
+        k = mat.get_extinctioncoefficient(500)
+        expected = (n - 1j * k) ** 2
+        assert abs(eps - expected) < 1e-12
+
+    # ------------------------------------------------------------------
+    # get_wl_range
+    # ------------------------------------------------------------------
+
+    def test_get_wl_range_nm(self):
+        mat = self._make_n_only()
+        lo, hi = mat.get_wl_range(unit='nm')
+        assert lo == pytest.approx(300.0)
+        assert hi == pytest.approx(700.0)
+
+    def test_get_wl_range_um(self):
+        mat = self._make_n_only()
+        lo, hi = mat.get_wl_range(unit='um')
+        assert lo == pytest.approx(0.3)
+        assert hi == pytest.approx(0.7)
+
+    def test_get_wl_range_eV(self):
+        mat = self._make_n_only()
+        lo, hi = mat.get_wl_range(unit='eV')
+        # 300 nm → higher eV, 700 nm → lower eV; returned as (min, max)
+        assert lo < hi
+        assert lo > 0

--- a/tests/test_optical_data.py
+++ b/tests/test_optical_data.py
@@ -1,3 +1,6 @@
+import math
+
+import numpy
 import pytest
 
 from refractivesqlite.optical_data import (
@@ -43,13 +46,26 @@ class TestTabulatedRefractiveIndexData:
         assert self.data.rangeMax == 1.0
 
     def test_get_refractiveindex_in_range(self):
-        # wavelength arg is in nm; 500 nm = 0.5 um
+        # 500 nm = 0.5 um
         n = self.data.get_refractiveindex(500)
         assert 1.3 < n < 1.6
 
-    def test_get_refractiveindex_out_of_range(self):
-        with pytest.raises(Exception, match="out of bounds"):
-            self.data.get_refractiveindex(2000)
+    def test_get_refractiveindex_out_of_range_returns_nan(self):
+        n = self.data.get_refractiveindex(2000)
+        assert math.isnan(n)
+
+    def test_get_refractiveindex_array_input(self):
+        wls = numpy.array([300, 500, 700, 1000])
+        result = self.data.get_refractiveindex(wls)
+        assert result.shape == (4,)
+        assert not numpy.any(numpy.isnan(result))
+
+    def test_get_refractiveindex_array_partial_nan(self):
+        wls = numpy.array([300, 500, 2000])
+        result = self.data.get_refractiveindex(wls)
+        assert not numpy.isnan(result[0])
+        assert not numpy.isnan(result[1])
+        assert numpy.isnan(result[2])
 
     def test_get_complete_refractive(self):
         result = self.data.get_complete_refractive()
@@ -78,9 +94,15 @@ class TestExtinctionCoefficientData:
         k = self.data.get_extinction_coefficient(500)
         assert 0.0 < k < 0.05
 
-    def test_get_extinction_out_of_range(self):
-        with pytest.raises(Exception, match="out of bounds"):
-            self.data.get_extinction_coefficient(2000)
+    def test_get_extinction_out_of_range_returns_nan(self):
+        k = self.data.get_extinction_coefficient(2000)
+        assert math.isnan(k)
+
+    def test_get_extinction_array_input(self):
+        wls = numpy.array([300, 500, 700, 1000])
+        result = self.data.get_extinction_coefficient(wls)
+        assert result.shape == (4,)
+        assert not numpy.any(numpy.isnan(result))
 
     def test_get_complete_extinction(self):
         result = self.data.get_complete_extinction()
@@ -102,15 +124,60 @@ class TestFormulaRefractiveIndexData:
 
     def test_get_refractiveindex_in_range(self):
         data = self._make_sellmeier()
-        n = data.get_refractiveindex(589000)  # 589 um in nm
+        n = data.get_refractiveindex(589)  # 589 nm
         assert 1.4 < n < 1.6
 
-    def test_get_refractiveindex_out_of_range(self):
+    def test_get_refractiveindex_out_of_range_returns_nan(self):
         data = self._make_sellmeier()
-        with pytest.raises(Exception, match="out of bounds"):
-            data.get_refractiveindex(100)
+        n = data.get_refractiveindex(100)  # 100 nm, below rangeMin
+        assert math.isnan(n)
+
+    def test_get_refractiveindex_array_input(self):
+        data = self._make_sellmeier()
+        wls = numpy.array([400, 500, 600, 700])  # nm
+        result = data.get_refractiveindex(wls)
+        assert result.shape == (4,)
+        assert not numpy.any(numpy.isnan(result))
+
+    def test_get_refractiveindex_array_partial_nan(self):
+        data = self._make_sellmeier()
+        wls = numpy.array([100, 589, 3000])  # nm — first and last out of range
+        result = data.get_refractiveindex(wls)
+        assert numpy.isnan(result[0])
+        assert not numpy.isnan(result[1])
+        assert numpy.isnan(result[2])
 
     def test_get_complete_refractive_length(self):
         data = self._make_sellmeier()
         result = data.get_complete_refractive()
         assert len(result) == 50
+
+    def test_formula4_correctness(self):
+        # TiO2 (anatase) — formula 4 from refractiveindex.info
+        # Coefficients from Devore (1951), valid 0.43–1.53 um
+        data = FormulaRefractiveIndexData(
+            formula=4,
+            rangeMin=0.43,
+            rangeMax=1.53,
+            coefficients=[
+                5.913, 0.2441, 0.0803, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0,
+            ],
+            interpolation_points=20,
+        )
+        n = data.get_refractiveindex(600)  # 600 nm
+        # TiO2 has n ~ 2.5 in the visible
+        assert 2.0 < n < 3.5
+
+    def test_formula4_short_coefficients(self):
+        # Ensure formula 4 doesn't crash with fewer than 9 coefficients
+        data = FormulaRefractiveIndexData(
+            formula=4,
+            rangeMin=0.3,
+            rangeMax=1.0,
+            coefficients=[2.0],  # only C0
+            interpolation_points=5,
+        )
+        n = data.get_refractiveindex(500)
+        assert not math.isnan(n)
+        assert n == pytest.approx(math.sqrt(2.0), rel=1e-6)


### PR DESCRIPTION
Seven improvements applied:

1. New _units.py: wavelength unit registry (m, mm, um, nm, A, cm-1, THz, eV) with to_nm/from_nm helpers for lossless conversions.

2. Fix formula 4 (RefractiveIndex.INFO): replaced hardcoded two-term Lorentz expansion with a step-4 loop over coefficients[1:9] and a step-2 loop for the polynomial tail (coefficients[9:]), matching the spec. Zero-padding prevents index errors for short coefficient lists.

3. NumPy array input: all get_refractiveindex / get_extinction_coefficient methods now accept scalar or array-like wavelengths.

4. NaN for out-of-range: replaced exception raises with NaN returns (bounds_error=False on interp1d; masking in formula path), making vectorised workflows convenient.

5. unit= parameter on Material.get_refractiveindex and Material.get_extinctioncoefficient; defaults to 'nm'.

6. Material.get_epsilon(wavelength, unit, convention): returns complex permittivity (n+ik)^2 with physics/engineering sign convention option.

7. Material.get_wl_range(unit): returns (min, max) wavelength range in the requested unit.

8. Builder: module-level _catalog_cache avoids re-reading library.yml on repeated calls; uses CSafeLoader (falls back to SafeLoader) for speed.

9. Fix: support both 'range' and 'wavelength_range' YAML keys in Material.__init__ (newer upstream uses 'range').

10. Tests updated and extended: 50 tests, all passing.