### PR TITLE
Update README and Tutorial to document new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ YML parsing is based on a modified version of `refractiveIndex.py` from the [PyT
 - Build a local SQLite database from the upstream YML folder or directly from a `.zip` URL.
 - Search materials by name, shelf/book/page, refractive index (*n*), or extinction coefficient (*k*).
 - Run arbitrary SQL queries against the database.
-- Load a material and retrieve *n* or *k* at any wavelength (interpolated).
+- Load a material and retrieve *n*, *k*, or ε at any wavelength — **scalar or NumPy array input**.
+- Query in **any wavelength unit**: nm, µm, m, mm, Å, cm⁻¹, THz, or eV.
+- Out-of-range wavelengths return **NaN** instead of raising exceptions, enabling clean vectorised workflows.
 - Export optical data to NumPy arrays or CSV files.
 - Use `Material.FromLists` to wrap your own *n*/*k* data without a database.
 
@@ -51,11 +53,17 @@ db.search_pages("BK7")
 
 # 4. Load and query it
 mat = db.get_material(pageid)
-print(mat.get_refractiveindex(589))        # n at 589 nm
-print(mat.get_extinctioncoefficient(589))  # k at 589 nm
+print(mat.get_refractiveindex(589))          # n at 589 nm
+print(mat.get_refractiveindex(2.48, unit='eV'))   # same point, eV input
+print(mat.get_extinctioncoefficient(589))    # k at 589 nm
+print(mat.get_epsilon(589))                  # complex permittivity ε = (n+ik)²
 
-# 5. Get everything as a NumPy array  (shape N×2: wavelength µm, value)
+# 5. Vectorised query over a wavelength array
 import numpy as np
+wls = np.linspace(400, 800, 200)             # nm
+n_arr = mat.get_refractiveindex(wls)         # shape (200,), NaN outside range
+
+# 6. Get everything as a NumPy array  (shape N×2: wavelength µm, value)
 n = np.array(mat.get_complete_refractive())
 k = np.array(mat.get_complete_extinction())
 ```
@@ -138,14 +146,75 @@ db.get_material_csv_all(outputfolder="output/")
 
 Returned by `db.get_material()`, or built from your own data with `Material.FromLists`.
 
+#### Predicates
+
 ```python
 mat.has_refractive()                   # bool
 mat.has_extinction()                   # bool
-mat.get_page_info()                    # OrderedDict of database metadata
+mat.get_page_info()                    # dict of database metadata
+```
 
-mat.get_refractiveindex(550)           # n at 550 nm (interpolated)
-mat.get_extinctioncoefficient(550)     # k at 550 nm (interpolated)
+#### Point queries — scalar or array input
 
+All query methods accept a scalar wavelength **or** a NumPy array. Values outside the
+valid range return **NaN** rather than raising an exception.
+
+```python
+# Default unit: nm
+mat.get_refractiveindex(550)                       # scalar
+mat.get_extinctioncoefficient(550)                 # scalar
+
+# Any supported unit (see table below)
+mat.get_refractiveindex(0.55, unit='um')           # µm
+mat.get_refractiveindex(2.25, unit='eV')           # electron-volts
+mat.get_refractiveindex(18182, unit='cm-1')        # wavenumbers
+
+# Vectorised — returns ndarray, NaN outside valid range
+import numpy as np
+wls = np.linspace(400, 800, 200)
+n = mat.get_refractiveindex(wls)           # shape (200,)
+k = mat.get_extinctioncoefficient(wls)     # shape (200,)
+```
+
+**Supported units:**
+
+| `unit=` | Physical quantity |
+|---|---|
+| `'m'` | metres |
+| `'mm'` | millimetres |
+| `'um'` | micrometres (µm) |
+| `'nm'` *(default)* | nanometres |
+| `'A'` | ångströms |
+| `'cm-1'` | wavenumbers (cm⁻¹) |
+| `'THz'` | terahertz frequency |
+| `'eV'` | electron-volts |
+
+#### Complex permittivity
+
+```python
+# ε = (n + ik)² — physics convention (exp(−iωt)), default
+eps = mat.get_epsilon(550)
+
+# ε = (n − ik)² — engineering convention (exp(+iωt))
+eps = mat.get_epsilon(550, convention='exp_plus_i_omega_t')
+
+# Works with any unit and array input
+eps = mat.get_epsilon(np.linspace(400, 800, 200), unit='nm')
+```
+
+If no extinction coefficient is available, *k* is taken as 0 and ε is real.
+
+#### Wavelength range
+
+```python
+lo, hi = mat.get_wl_range()            # (min, max) in nm
+lo, hi = mat.get_wl_range(unit='um')   # in µm
+lo, hi = mat.get_wl_range(unit='eV')   # in eV
+```
+
+#### Bulk data retrieval
+
+```python
 mat.get_complete_refractive()          # list of [wavelength_µm, n]
 mat.get_complete_extinction()          # list of [wavelength_µm, k]
 
@@ -164,6 +233,7 @@ mat = Material.FromLists(
     wavelengths_e=[0.4, 0.6, 0.8],  extinction=[1e-4, 8e-5, 6e-5],
 )
 print(mat.get_refractiveindex(500))
+print(mat.get_epsilon(500))
 ```
 
 ---
@@ -177,11 +247,12 @@ refractivesqlite/
 ├── material.py        # Material — per-entry interface
 ├── optical_data.py    # RefractiveIndexData, FormulaRefractiveIndexData,
 │                      #   TabulatedRefractiveIndexData, ExtinctionCoefficientData
-├── builder.py         # DB creation from YML folder
+├── builder.py         # DB creation from YML folder (with catalog cache)
 ├── downloader.py      # download_rii_zip
 ├── models.py          # Shelf / Book / Page / Entry namedtuples
 ├── exceptions.py      # NoExtinctionCoefficient, FormulaNotImplemented
-└── _constants.py      # RII_DATABASE_URL
+├── _constants.py      # RII_DATABASE_URL
+└── _units.py          # Wavelength unit registry (to_nm / from_nm)
 
 examples/
 └── Tutorial.ipynb     # interactive walkthrough

--- a/examples/Tutorial.ipynb
+++ b/examples/Tutorial.ipynb
@@ -9,7 +9,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.0"
+   "version": "3.11.0"
   }
  },
  "cells": [
@@ -28,7 +28,9 @@
     "- Search materials by name, shelf/book/page, refractive index (*n*), or extinction coefficient (*k*).\n",
     "- Execute raw SQL queries for power users.\n",
     "- Export data to NumPy arrays or CSV files.\n",
-    "- Retrieve *n* and *k* at arbitrary wavelengths.\n",
+    "- Retrieve *n*, *k*, and complex permittivity ε at arbitrary wavelengths — **scalar or array input**.\n",
+    "- Query using **any wavelength unit**: nm, µm, m, mm, Å, cm⁻¹, THz, or eV.\n",
+    "- Out-of-range wavelengths return **NaN** for clean vectorised workflows.\n",
     "\n",
     "## Database schema\n",
     "\n",
@@ -56,11 +58,12 @@
     "├── database.py        # Database class — search & retrieval\n",
     "├── material.py        # Material class — per-material interface\n",
     "├── optical_data.py    # Formula/tabulated n and k data classes\n",
-    "├── builder.py         # DB creation from YML folder\n",
+    "├── builder.py         # DB creation from YML folder (with catalog cache)\n",
     "├── downloader.py      # Download upstream .zip\n",
     "├── models.py          # Shelf / Book / Page / Entry namedtuples\n",
     "├── exceptions.py      # NoExtinctionCoefficient, FormulaNotImplemented\n",
-    "└── _constants.py      # RII_DATABASE_URL\n",
+    "├── _constants.py      # RII_DATABASE_URL\n",
+    "└── _units.py          # Wavelength unit registry (to_nm / from_nm)\n",
     "```\n",
     "\n",
     "The public API you need day-to-day is just two names:\n",
@@ -78,7 +81,7 @@
     "---\n",
     "## 1. Create / open the database\n",
     "\n",
-    "> **Once you have created the database you do not need to recreate it.** Skip straight to *1.3 Open an existing database* on subsequent runs."
+    "> **Once you have created the database you do not need to recreate it.** Skip straight to *1.4 Open an existing database* on subsequent runs."
    ]
   },
   {
@@ -94,9 +97,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "create-url",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite import Database\n",
@@ -118,9 +121,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "create-custom-url",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite import Database\n",
@@ -144,9 +147,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "create-folder",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite import Database\n",
@@ -169,9 +172,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "open-existing",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite import Database\n",
@@ -190,9 +193,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "check-url",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.check_url_version()"
@@ -219,9 +222,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-all",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_pages()"
@@ -239,9 +242,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-term",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_pages(\"otanicar\")"
@@ -259,9 +262,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-exact",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_pages(\"au\", exact=True)"
@@ -279,9 +282,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-id",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_id(1542)"
@@ -299,9 +302,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-n",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_n(n=0.3, delta_n=0.0001)"
@@ -319,9 +322,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-k",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_k(k=0.3, delta_k=0.0001)"
@@ -339,9 +342,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "search-nk",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "db.search_nk(n=0.3, delta_n=0.1, k=0.3, delta_k=0.1)"
@@ -360,9 +363,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "custom-sql-1",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# All pages in main/Ag whose name contains 'k'\n",
@@ -374,9 +377,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "custom-sql-2",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# Extinction coefficients for page 1 in wavelength range [0.3, 0.4] µm\n",
@@ -388,9 +391,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "custom-sql-3",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# All materials with both n and k measured at exactly 0.301 µm\n",
@@ -427,9 +430,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-load",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# Page 5 = main / Ag / Johnson\n",
@@ -446,9 +449,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-info",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "info = mat.get_page_info()\n",
@@ -471,9 +474,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-availability",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "print(\"Has refractive index (n)?\", mat.has_refractive())\n",
@@ -492,9 +495,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-numpy",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -521,9 +524,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-numpy-shortcut",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "n_arr = db.get_material_n_numpy(5)\n",
@@ -537,16 +540,16 @@
    "id": "mat-wavelength-header",
    "metadata": {},
    "source": [
-    "### 3.5 Query at a specific wavelength\n",
+    "### 3.5 Query at a specific wavelength (default: nm)\n",
     "\n",
-    "Pass wavelength in **nanometres**. The value is interpolated if it falls within the measured range."
+    "Pass wavelength in **nanometres** (default). The value is interpolated if it falls within the measured range; otherwise **NaN** is returned."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-wavelength",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite.exceptions import NoExtinctionCoefficient\n",
@@ -578,9 +581,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-csv-single",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "mat.to_csv(output=\"Ag_Johnson.csv\")"
@@ -588,9 +591,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-csv-via-db",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# Shortcut: load and export in one call\n",
@@ -599,9 +602,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "mat-csv-all",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "# Export every material in the database (can take a while)\n",
@@ -629,9 +632,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "viz-single",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -673,9 +676,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "viz-compare",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -726,9 +729,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "adv-material-fromlists",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -765,9 +768,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "adv-exceptions",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite.exceptions import NoExtinctionCoefficient\n",
@@ -799,9 +802,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "adv-models",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite.models import Shelf, Book, Page, Entry\n",
@@ -822,14 +825,16 @@
    "source": [
     "### 5.4 Low-level builder access\n",
     "\n",
-    "You can call the builder functions directly to inspect the YML catalogue without going through a `Database` object."
+    "You can call the builder functions directly to inspect the YML catalogue without going through a `Database` object.\n",
+    "\n",
+    "> The builder caches the parsed `library.yml` in memory, so repeated calls to `extract_entry_list` with the same path incur no additional I/O."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "adv-builder",
    "metadata": {},
-   "execution_count": null,
    "outputs": [],
    "source": [
     "from refractivesqlite.builder import extract_entry_list, print_pretty_entry_list\n",
@@ -838,6 +843,275 @@
     "# print(f\"Found {len(entries)} entries\")\n",
     "# print_pretty_entry_list(entries[:10])       # show first 10\n",
     "print(\"(Uncomment the lines above when a local YML folder is available.)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section-units",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6. Multi-unit and vectorised queries\n",
+    "\n",
+    "All query methods — `get_refractiveindex`, `get_extinctioncoefficient`, `get_epsilon`, and `get_wl_range` — accept an optional `unit=` keyword.  \n",
+    "Supported units are: **`'m'`, `'mm'`, `'um'`, `'nm'`** (default)**, `'A'`, `'cm-1'`, `'THz'`, `'eV'`**.\n",
+    "\n",
+    "All methods also accept **scalar or array-like** wavelength input.  \n",
+    "Wavelengths outside the material's valid range return **NaN** instead of raising an exception."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "units-scalar-header",
+   "metadata": {},
+   "source": [
+    "### 6.1 Scalar queries in different units\n",
+    "\n",
+    "The following four calls all query the same physical wavelength (≈ 633 nm)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "units-scalar",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from refractivesqlite import Material\n",
+    "\n",
+    "# Build a simple glass with n data in um (as the database stores internally)\n",
+    "pageinfo = {\"pageid\": 0, \"shelf\": \"demo\", \"book\": \"Glass\", \"page\": \"Cauchy\"}\n",
+    "wl_um = list(np.linspace(0.3, 1.0, 100))\n",
+    "n_vals = [1.5 + 0.005 / w**2 for w in wl_um]\n",
+    "mat = Material.FromLists(pageinfo, wavelengths_r=wl_um, refractive=n_vals)\n",
+    "\n",
+    "# All four evaluate at the same point\n",
+    "print(f\"n(633 nm)       = {mat.get_refractiveindex(633, unit='nm'):.5f}\")\n",
+    "print(f\"n(0.633 um)     = {mat.get_refractiveindex(0.633, unit='um'):.5f}\")\n",
+    "print(f\"n(6330 A)       = {mat.get_refractiveindex(6330, unit='A'):.5f}\")\n",
+    "print(f\"n(15798 cm-1)   = {mat.get_refractiveindex(15798, unit='cm-1'):.5f}\")\n",
+    "print(f\"n(1.959 eV)     = {mat.get_refractiveindex(1.959, unit='eV'):.5f}\")\n",
+    "print(f\"n(473.6 THz)    = {mat.get_refractiveindex(473.6, unit='THz'):.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "units-array-header",
+   "metadata": {},
+   "source": [
+    "### 6.2 Vectorised query — array of wavelengths\n",
+    "\n",
+    "Pass a NumPy array; the result is a matching NumPy array. Values outside the valid range are `NaN`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "units-array",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from refractivesqlite import Material\n",
+    "\n",
+    "pageinfo = {\"pageid\": 0, \"shelf\": \"demo\", \"book\": \"Glass\", \"page\": \"Cauchy\"}\n",
+    "wl_um = list(np.linspace(0.3, 1.0, 100))\n",
+    "n_vals = [1.5 + 0.005 / w**2 for w in wl_um]\n",
+    "mat = Material.FromLists(pageinfo, wavelengths_r=wl_um, refractive=n_vals)\n",
+    "\n",
+    "# Dense wavelength grid — some points outside the material range\n",
+    "wls = np.linspace(200, 1200, 500)          # nm\n",
+    "n   = mat.get_refractiveindex(wls)         # ndarray, NaN outside [300, 1000] nm\n",
+    "\n",
+    "print(f\"Query array shape : {n.shape}\")\n",
+    "print(f\"NaN count         : {np.sum(np.isnan(n))}  \"\n",
+    "      f\"(wavelengths outside [300, 1000] nm)\")\n",
+    "\n",
+    "plt.figure(figsize=(8, 3))\n",
+    "plt.plot(wls, n, linewidth=2, color='steelblue')\n",
+    "plt.xlabel(\"Wavelength (nm)\")\n",
+    "plt.ylabel(\"n\")\n",
+    "plt.title(\"Vectorised query — NaN outside valid range\")\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "units-eV-header",
+   "metadata": {},
+   "source": [
+    "### 6.3 Query in eV — common in photonics and solid-state physics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "units-eV",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from refractivesqlite import Material\n",
+    "\n",
+    "pageinfo = {\"pageid\": 0, \"shelf\": \"demo\", \"book\": \"Glass\", \"page\": \"Cauchy\"}\n",
+    "wl_um = list(np.linspace(0.3, 1.0, 100))\n",
+    "n_vals = [1.5 + 0.005 / w**2 for w in wl_um]\n",
+    "mat = Material.FromLists(pageinfo, wavelengths_r=wl_um, refractive=n_vals)\n",
+    "\n",
+    "energies = np.linspace(1.2, 4.5, 300)     # eV\n",
+    "n = mat.get_refractiveindex(energies, unit='eV')\n",
+    "\n",
+    "plt.figure(figsize=(8, 3))\n",
+    "plt.plot(energies, n, linewidth=2, color='darkorange')\n",
+    "plt.xlabel(\"Photon energy (eV)\")\n",
+    "plt.ylabel(\"n\")\n",
+    "plt.title(\"Refractive index vs photon energy\")\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "epsilon-header",
+   "metadata": {},
+   "source": [
+    "### 6.4 Complex permittivity ε\n",
+    "\n",
+    "`get_epsilon` returns ε = (n + ik)² using the **exp(−iωt)** physics convention by default.  \n",
+    "Pass `convention='exp_plus_i_omega_t'` for the engineering (EE) sign convention.  \n",
+    "Accepts the same `unit=` keyword and array input as the other query methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "epsilon-scalar",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from refractivesqlite import Material\n",
+    "\n",
+    "# Material with both n and k\n",
+    "pageinfo = {\"pageid\": 0, \"shelf\": \"demo\", \"book\": \"Metal\", \"page\": \"synthetic\"}\n",
+    "wl_um  = list(np.linspace(0.3, 1.0, 80))\n",
+    "n_vals = [0.2 + 0.1 * w for w in wl_um]\n",
+    "k_vals = [3.5 - 1.0 * w for w in wl_um]\n",
+    "\n",
+    "mat = Material.FromLists(\n",
+    "    pageinfo,\n",
+    "    wavelengths_r=wl_um, refractive=n_vals,\n",
+    "    wavelengths_e=wl_um, extinction=k_vals,\n",
+    ")\n",
+    "\n",
+    "eps = mat.get_epsilon(633)           # nm, physics convention\n",
+    "n   = mat.get_refractiveindex(633)\n",
+    "k   = mat.get_extinctioncoefficient(633)\n",
+    "\n",
+    "print(f\"n  = {n:.4f}\")\n",
+    "print(f\"k  = {k:.4f}\")\n",
+    "print(f\"ε  = {eps:.4f}\")\n",
+    "print(f\"ε  = ({eps.real:.4f}) + ({eps.imag:.4f})i\")\n",
+    "print(f\"\\nVerification: (n+ik)² = ({n:.4f}+{k:.4f}i)² = {(n+1j*k)**2:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "epsilon-array",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "wls = np.linspace(300, 1000, 300)       # nm\n",
+    "eps = mat.get_epsilon(wls)              # shape (300,), complex\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))\n",
+    "\n",
+    "ax1.plot(wls, eps.real, color='steelblue', linewidth=2)\n",
+    "ax1.axhline(0, color='k', linewidth=0.6, linestyle='--')\n",
+    "ax1.set_xlabel(\"Wavelength (nm)\")\n",
+    "ax1.set_ylabel(r\"Re(ε)\")\n",
+    "ax1.set_title(\"Real part of permittivity\")\n",
+    "ax1.grid(True, alpha=0.3)\n",
+    "\n",
+    "ax2.plot(wls, eps.imag, color='tomato', linewidth=2)\n",
+    "ax2.set_xlabel(\"Wavelength (nm)\")\n",
+    "ax2.set_ylabel(r\"Im(ε)\")\n",
+    "ax2.set_title(\"Imaginary part of permittivity\")\n",
+    "ax2.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wl-range-header",
+   "metadata": {},
+   "source": [
+    "### 6.5 Wavelength range in any unit\n",
+    "\n",
+    "`get_wl_range(unit)` returns the `(min, max)` valid wavelength range converted to the requested unit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wl-range",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from refractivesqlite import Material\n",
+    "\n",
+    "pageinfo = {\"pageid\": 0, \"shelf\": \"demo\", \"book\": \"Glass\", \"page\": \"Cauchy\"}\n",
+    "wl_um = list(np.linspace(0.4, 0.9, 50))\n",
+    "n_vals = [1.5 + 0.01 / w**2 for w in wl_um]\n",
+    "mat = Material.FromLists(pageinfo, wavelengths_r=wl_um, refractive=n_vals)\n",
+    "\n",
+    "for unit in ['nm', 'um', 'm', 'A', 'cm-1', 'THz', 'eV']:\n",
+    "    lo, hi = mat.get_wl_range(unit=unit)\n",
+    "    print(f\"  {unit:>5s} : ({lo:.4g}, {hi:.4g})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "units-module-header",
+   "metadata": {},
+   "source": [
+    "### 6.6 Direct access to the unit registry\n",
+    "\n",
+    "The `_units` module is private but importable if you need standalone wavelength conversions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "units-module",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from refractivesqlite._units import to_nm, from_nm, SUPPORTED_UNITS\n",
+    "import numpy as np\n",
+    "\n",
+    "print(\"Supported units:\", SUPPORTED_UNITS)\n",
+    "\n",
+    "wl_eV = np.array([1.0, 2.0, 3.0, 4.0])   # eV\n",
+    "wl_nm = to_nm(wl_eV, 'eV')               # → nm\n",
+    "wl_back = from_nm(wl_nm, 'eV')            # → eV\n",
+    "\n",
+    "print(\"\\nInput (eV):\", wl_eV)\n",
+    "print(\"→ nm:      \", wl_nm.round(2))\n",
+    "print(\"→ back eV: \", wl_back.round(6))"
    ]
   }
  ]


### PR DESCRIPTION
README:
- Add multi-unit support (unit= parameter) to quick start and Material API sections, with a supported-units table.
- Document get_epsilon(): complex permittivity with sign-convention option.
- Document get_wl_range(unit): valid range in any unit.
- Add vectorised / array-input note with NaN-for-out-of-range behaviour.
- Add _units.py to package layout.

Tutorial (examples/Tutorial.ipynb):
- Extend to 77 cells (37 code, 40 markdown).
- New Section 6 "Multi-unit and vectorised queries": 6.1 Same wavelength queried in nm, um, Å, cm-1, eV, THz. 6.2 Vectorised array query with matplotlib NaN visualisation. 6.3 Query in eV with dispersion plot. 6.4 Complex permittivity: scalar + array query, Re/Im plots. 6.5 get_wl_range() across all 7 units. 6.6 Direct _units module usage (to_nm / from_nm).
- Note on catalog cache in Section 5.4 builder cell.
- All cells validated: valid JSON, all 37 code cells parse cleanly.