### PR TITLE
Fix compatibility with latest database format (2025-02-23)

### DIFF
--- a/refractivesqlite/builder.py
+++ b/refractivesqlite/builder.py
@@ -14,12 +14,30 @@ from refractivesqlite import material as material_module
 _catalog_cache = {}
 
 
+def _find_catalog_file(db_path):
+    """Locate the catalog YAML file in *db_path*.
+
+    Newer databases (>= 2025) use ``catalog-nk.yml``; older ones use
+    ``library.yml``.  Returns the full path to whichever is found.
+
+    :raises FileNotFoundError: If neither file exists.
+    """
+    for name in ('catalog-nk.yml', 'library.yml'):
+        path = os.path.join(db_path, name)
+        if os.path.isfile(path):
+            return path
+    raise FileNotFoundError(
+        'No catalog file found in {}. '
+        'Expected catalog-nk.yml or library.yml.'.format(db_path))
+
+
 def extract_entry_list(db_path):
     """Return a list of :class:`~refractivesqlite.models.Entry` objects
-    parsed from *db_path*/library.yml.
+    parsed from the catalog file in *db_path*.
 
-    Results are cached per normalised path so that the YAML file is read
-    at most once per process.
+    Supports both ``catalog-nk.yml`` (>= 2025) and ``library.yml``
+    (legacy).  Results are cached per normalised path so that the YAML
+    file is read at most once per process.
     """
     entries = []
     referencePath = os.path.normpath(db_path)
@@ -27,14 +45,15 @@ def extract_entry_list(db_path):
     if referencePath in _catalog_cache:
         catalog = _catalog_cache[referencePath]
     else:
-        library_yml_path = os.path.join(
-            referencePath, os.path.normpath('library.yml'))
-        with open(library_yml_path, 'r') as f:
+        catalog_path = _find_catalog_file(referencePath)
+        with open(catalog_path, 'r') as f:
             catalog = yaml.load(f, Loader=_YamlLoader)
         _catalog_cache[referencePath] = catalog
 
     idx = 0
     for sh in catalog:
+        if 'DIVIDER' in sh or 'SHELF' not in sh:
+            continue
         shelf = Shelf(sh['SHELF'], sh['name'])
         for b in sh['content']:
             if 'DIVIDER' not in b:

--- a/refractivesqlite/database.py
+++ b/refractivesqlite/database.py
@@ -47,9 +47,11 @@ class Database:
                        refractive index database from
         :param interpolation_points: The number of interpolation_points to use
         '''
-        download_rii_zip(riiurl=riiurl)
+        db_folder = download_rii_zip(riiurl=riiurl)
+        if db_folder is None:
+            raise RuntimeError("Failed to download the database from " + riiurl)
         self.create_database_from_folder(
-            "database", interpolation_points=interpolation_points)
+            db_folder, interpolation_points=interpolation_points)
 
     def check_url_version(self):
         print(RII_DATABASE_URL)

--- a/refractivesqlite/downloader.py
+++ b/refractivesqlite/downloader.py
@@ -1,4 +1,5 @@
 import io
+import os
 import zipfile
 
 import requests
@@ -8,20 +9,48 @@ from refractivesqlite._constants import RII_DATABASE_URL
 
 def download_rii_zip(output_folder="", riiurl=RII_DATABASE_URL):
     """
-    Download the refractive index info database
+    Download and extract the refractive index info database zip.
 
-    :param output_folder: The output folder ./ as default
-    :param riiurl: The url from where to download the database
-    :returns: True on success, false otherwise
+    :param output_folder: Directory to extract into (default: current dir).
+    :param riiurl: URL of the database zip archive.
+    :returns: Path to the extracted database folder on success, or None.
     """
     print("Making request to", riiurl)
     r = requests.get(riiurl)
-    if r.ok:
-        print("Downloaded and extracting...")
-        z = zipfile.ZipFile(io.BytesIO(r.content))
-        z.extractall(path=output_folder)
-        print("Wrote", output_folder+"/database", "from", riiurl)
-        return True
-    else:
+    if not r.ok:
         print("There was a problem with the request.")
-        return False
+        return None
+
+    print("Downloaded and extracting...")
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    z.extractall(path=output_folder)
+
+    # Detect the extracted database folder by looking for the catalog file
+    db_folder = _find_database_folder(output_folder)
+    print("Wrote", db_folder, "from", riiurl)
+    return db_folder
+
+
+def _find_database_folder(base_path):
+    """Find the database folder inside *base_path* after zip extraction.
+
+    Looks for a directory containing ``catalog-nk.yml`` or ``library.yml``.
+    Falls back to ``database`` if neither is found (backwards-compatible).
+    """
+    base = base_path or "."
+    # Check common locations
+    for candidate in ("database", "."):
+        folder = os.path.join(base, candidate) if candidate != "." else base
+        for catalog_name in ("catalog-nk.yml", "library.yml"):
+            if os.path.isfile(os.path.join(folder, catalog_name)):
+                return folder
+    # Walk one level to find any folder with a catalog file
+    if os.path.isdir(base):
+        for name in os.listdir(base):
+            folder = os.path.join(base, name)
+            if os.path.isdir(folder):
+                for catalog_name in ("catalog-nk.yml", "library.yml"):
+                    if os.path.isfile(os.path.join(folder, catalog_name)):
+                        return folder
+    # Default fallback
+    return os.path.join(base, "database")


### PR DESCRIPTION
The latest refractiveindex.info database (v2025-02-23) renamed library.yml to catalog-nk.yml and added DIVIDER entries at the top level of the catalog. This broke database creation.

Changes:

builder.py:
- New _find_catalog_file() helper that tries catalog-nk.yml first, then falls back to library.yml, raising FileNotFoundError if neither exists.
- extract_entry_list() now skips DIVIDER entries at the top level (the new catalog has entries like {DIVIDER: "Research data"} before the first SHELF entry).
- Backwards-compatible with the old 2019 library.yml format.

downloader.py:
- download_rii_zip() now returns the detected database folder path instead of always assuming "database".
- New _find_database_folder() searches the extracted content for the folder containing the catalog file, falling back to "database".

database.py:
- create_database_from_url() uses the returned folder path from the downloader instead of hardcoding "database".

Tested with simulated old (library.yml) and new (catalog-nk.yml + top-level DIVIDER) formats. All 50 tests pass.

https://claude.ai/code/session_01Phkn3d5mjyKCeybKjgC1zw