### PR TITLE
Fix demo notebook formula cell: add get_material_from_yml()

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,12 @@ results = db.search_custom(
 #### Retrieving data
 
 ```python
-mat = db.get_material(37)              # returns a Material object
+mat = db.get_material(37)              # returns a Material object (tabulated)
+
+# Load from YAML to access the original dispersion formula & coefficients
+mat_yml = db.get_material_from_yml(37, yml_database_path="database")
+print(mat_yml.refractiveIndex.formula)       # e.g. 1 (Sellmeier)
+print(mat_yml.refractiveIndex.coefficients)  # list of floats
 
 # NumPy arrays directly from the database (shape N×2)
 n_arr = db.get_material_n_numpy(37)

--- a/examples/Demo_RefractiveIndexInfo.ipynb
+++ b/examples/Demo_RefractiveIndexInfo.ipynb
@@ -360,19 +360,7 @@
    "cell_type": "markdown",
    "id": "sec5-header",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## 5. Dispersion formula and coefficients\n",
-    "\n",
-    "SiO₂ Malitson uses a 3-term Sellmeier formula:\n",
-    "\n",
-    "$$n^2 - 1 = \\frac{B_1 \\lambda^2}{\\lambda^2 - C_1^2} + \\frac{B_2 \\lambda^2}{\\lambda^2 - C_2^2} + \\frac{B_3 \\lambda^2}{\\lambda^2 - C_3^2}$$\n",
-    "\n",
-    "The website shows:\n",
-    "- $B_1$ = 0.6961663, $C_1²$ = 0.0684043²\n",
-    "- $B_2$ = 0.4079426, $C_2²$ = 0.1162414²\n",
-    "- $B_3$ = 0.8974794, $C_3²$ = 9.896161²"
-   ]
+   "source": "---\n## 5. Dispersion formula and coefficients\n\nSiO₂ Malitson uses a 3-term Sellmeier formula:\n\n$$n^2 - 1 = \\frac{B_1 \\lambda^2}{\\lambda^2 - C_1^2} + \\frac{B_2 \\lambda^2}{\\lambda^2 - C_2^2} + \\frac{B_3 \\lambda^2}{\\lambda^2 - C_3^2}$$\n\nThe website shows:\n- $B_1$ = 0.6961663, $C_1²$ = 0.0684043²\n- $B_2$ = 0.4079426, $C_2²$ = 0.1162414²\n- $B_3$ = 0.8974794, $C_3²$ = 9.896161²\n\n**Note:** `db.get_material()` loads tabulated data from SQLite — the\noriginal formula coefficients are not stored there.  To access the\ndispersion formula, use `db.get_material_from_yml()` which reads the\noriginal YAML file directly.  This requires the YML database folder\n(downloaded during `create_database_from_url`)."
   },
   {
    "cell_type": "code",
@@ -380,31 +368,7 @@
    "id": "formula-coeffs",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Access the internal formula data\n",
-    "ri = mat.refractiveIndex\n",
-    "print(f\"Formula type: {ri.formula}  (1 = Sellmeier)\")\n",
-    "print(f\"Range: {ri.rangeMin} – {ri.rangeMax} µm\")\n",
-    "print(f\"\\nCoefficients:\")\n",
-    "\n",
-    "C = ri.coefficients\n",
-    "for i, c in enumerate(C):\n",
-    "    print(f\"  C[{i}] = {c}\")\n",
-    "\n",
-    "if ri.formula == 1 and len(C) >= 7:\n",
-    "    print(f\"\\nSellmeier interpretation:\")\n",
-    "    print(f\"  Constant term (should be 0): {C[0]}\")\n",
-    "    for term in range(3):\n",
-    "        B = C[1 + 2*term]\n",
-    "        Csq = C[2 + 2*term]\n",
-    "        print(f\"  Term {term+1}: B = {B}, C² = {Csq}² = {Csq**2:.8f}\")\n",
-    "\n",
-    "    # Print the formula\n",
-    "    print(f\"\\n  n² − 1 = \"\n",
-    "          f\"{C[1]}λ²/(λ² − {C[2]}²) + \"\n",
-    "          f\"{C[3]}λ²/(λ² − {C[4]}²) + \"\n",
-    "          f\"{C[5]}λ²/(λ² − {C[6]}²)\")"
-   ]
+   "source": "# Load material from YAML to access the original formula\n# Pass the path to the YML database folder (contains catalog-nk.yml or library.yml)\nmat_yml = db.get_material_from_yml(PAGEID, yml_database_path=\"database\")\n\nif mat_yml is None:\n    print(\"YAML database folder not found. Skipping formula display.\")\n    print(\"To use this cell, ensure the 'database/' folder exists\")\n    print(\"(it is created by db.create_database_from_url()).\")\nelse:\n    from refractivesqlite.optical_data import FormulaRefractiveIndexData\n\n    ri = mat_yml.refractiveIndex\n    if isinstance(ri, FormulaRefractiveIndexData):\n        FORMULA_NAMES = {\n            1: \"Sellmeier\", 2: \"Sellmeier-2\", 3: \"Polynomial\",\n            4: \"RefractiveIndex.INFO\", 5: \"Cauchy\", 6: \"Gases\",\n            7: \"Herzberger\", 8: \"Retro\", 9: \"Exotic\",\n        }\n        print(f\"Formula type: {ri.formula}  ({FORMULA_NAMES.get(ri.formula, '?')})\")\n        print(f\"Range: {ri.rangeMin} – {ri.rangeMax} µm\")\n        print(f\"\\nCoefficients:\")\n\n        C = ri.coefficients\n        for i, c in enumerate(C):\n            print(f\"  C[{i}] = {c}\")\n\n        if ri.formula == 1 and len(C) >= 7:\n            print(f\"\\nSellmeier interpretation:\")\n            print(f\"  Constant term (should be 0): {C[0]}\")\n            for term in range(3):\n                B = C[1 + 2*term]\n                Csq = C[2 + 2*term]\n                print(f\"  Term {term+1}: B = {B}, C = {Csq},  C² = {Csq**2:.10f}\")\n\n            print(f\"\\n  n² − 1 = \"\n                  f\"{C[1]}λ²/(λ² − {C[2]}²) + \"\n                  f\"{C[3]}λ²/(λ² − {C[4]}²) + \"\n                  f\"{C[5]}λ²/(λ² − {C[6]}²)\")\n    else:\n        print(\"This material uses tabulated data, not a formula.\")\n        print(f\"Range: {ri.rangeMin} – {ri.rangeMax} µm\")\n        print(f\"Data points: {len(ri.wavelengths)}\")"
   },
   {
    "cell_type": "markdown",
@@ -737,28 +701,7 @@
    "cell_type": "markdown",
    "id": "summary-header",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Summary of website features replicated\n",
-    "\n",
-    "| Website feature | Package method / code |\n",
-    "|---|---|\n",
-    "| Material lookup | `db.search_pages()`, `db.get_material(pageid)` |\n",
-    "| n at a wavelength | `mat.get_refractiveindex(λ, unit=)` |\n",
-    "| k at a wavelength | `mat.get_extinctioncoefficient(λ, unit=)` |\n",
-    "| n(λ) / k(λ) plot | `mat.get_refractiveindex(array, unit=)` + matplotlib |\n",
-    "| Wavelength range | `mat.get_wl_range(unit=)` |\n",
-    "| Complex permittivity ε | `mat.get_epsilon(λ, unit=)` → `.real`, `.imag` |\n",
-    "| Abbe number | `(n_d − 1) / (n_F − n_C)` |\n",
-    "| Chromatic dispersion | Numerical `dn/dλ` |\n",
-    "| Group index | `n − λ dn/dλ` |\n",
-    "| GVD, D parameter | `λ³/(2πc²) d²n/dλ²` |\n",
-    "| Dispersion formula | `mat.refractiveIndex.formula`, `.coefficients` |\n",
-    "| Fresnel R_p, R_s, R | `fresnel_reflectance(n1, n2, θ)` |\n",
-    "| Reflection phase | `fresnel_phase(n1, n2, θ)` |\n",
-    "| Brewster's angle | `arctan(n2/n1)` |\n",
-    "| Multi-dataset comparison | Loop over `search_custom()` results |"
-   ]
+   "source": "---\n## Summary of website features replicated\n\n| Website feature | Package method / code |\n|---|---|\n| Material lookup | `db.search_pages()`, `db.get_material(pageid)` |\n| n at a wavelength | `mat.get_refractiveindex(λ, unit=)` |\n| k at a wavelength | `mat.get_extinctioncoefficient(λ, unit=)` |\n| n(λ) / k(λ) plot | `mat.get_refractiveindex(array, unit=)` + matplotlib |\n| Wavelength range | `mat.get_wl_range(unit=)` |\n| Complex permittivity ε | `mat.get_epsilon(λ, unit=)` → `.real`, `.imag` |\n| Abbe number | `(n_d − 1) / (n_F − n_C)` |\n| Chromatic dispersion | Numerical `dn/dλ` |\n| Group index | `n − λ dn/dλ` |\n| GVD, D parameter | `λ³/(2πc²) d²n/dλ²` |\n| Dispersion formula | `db.get_material_from_yml()` → `ri.formula`, `ri.coefficients` |\n| Fresnel R_p, R_s, R | `fresnel_reflectance(n1, n2, θ)` |\n| Reflection phase | `fresnel_phase(n1, n2, θ)` |\n| Brewster's angle | `arctan(n2/n1)` |\n| Multi-dataset comparison | Loop over `search_custom()` results |"
   }
  ]
 }

--- a/refractivesqlite/database.py
+++ b/refractivesqlite/database.py
@@ -238,6 +238,39 @@ class Database:
                                       wavelengths_e=wavelengths_e,
                                       extinction=extinction)
 
+    def get_material_from_yml(self, pageid, yml_database_path="database"):
+        '''
+        Load a material directly from its YAML file, preserving the
+        original dispersion formula and coefficients.
+
+        Unlike :meth:`get_material` (which returns tabulated data from
+        SQLite), this method reads the YAML source so that
+        ``mat.refractiveIndex.formula`` and
+        ``mat.refractiveIndex.coefficients`` are available for
+        formula-based materials.
+
+        :param pageid: The pageid of the material
+        :param yml_database_path: Path to the YML database folder
+                                  (the one containing catalog-nk.yml
+                                  or library.yml). Default: "database".
+        :returns: Material loaded from YAML, or None if not found.
+        '''
+        pagedata = self._get_page_info(pageid)
+        if pagedata is None:
+            print("PageID not found.")
+            return None
+        filepath = pagedata['filepath']
+        yml_path = os.path.join(yml_database_path, 'data', filepath)
+        if not os.path.isfile(yml_path):
+            print("YAML file not found at", yml_path)
+            print("Pass yml_database_path= pointing to the folder "
+                  "containing catalog-nk.yml or library.yml.")
+            return None
+        mat = Material(yml_path)
+        mat.pageinfo = pagedata
+        print("Material", filepath, "loaded from YAML.")
+        return mat
+
     def get_material_n_numpy(self, pageid):
         '''
         Get the refraction index of a material


### PR DESCRIPTION
The formula-coeffs cell crashed with AttributeError because db.get_material() returns tabulated data from SQLite — the original dispersion formula type and coefficients are not stored in the database.

Fix:
- Add Database.get_material_from_yml(pageid, yml_database_path) that loads the material directly from the YAML source file, preserving the FormulaRefractiveIndexData with .formula and .coefficients.
- Update the demo notebook to use get_material_from_yml() for the formula section, with graceful fallback if the YAML folder is absent.
- Update README to document get_material_from_yml().

https://claude.ai/code/session_01Phkn3d5mjyKCeybKjgC1zw